### PR TITLE
Feat: Add github actions yaml file for assgin-author, add-reviewer, a…

### DIFF
--- a/.github/assign-reviewers.txt
+++ b/.github/assign-reviewers.txt
@@ -1,0 +1,2 @@
+# Academic Conference 2024 Members that are able to be assigned to reviewers
+2024/* @TaeHyoungKwon @jongfeel @dhlee3994 @fkdl0048 @wooyaggo86 @jeeyn @hongsam14 @yeslee-v

--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -5,6 +5,6 @@ labels:
   - label: "2024"
     files:
       - "2024/*"
-  - label: "The Psychology Of Computer Programming"
+  - label: "The Psychology of Computer Programming"
     files:
       - "2024/ThePsychologyOfComputerProgramming/*"

--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -1,0 +1,10 @@
+# NOTE: 추후에 각각 책의 라벨이 추가될 때 마다 확인 후 추가 필요
+
+version: 1
+labels:
+  - label: "2024"
+    files:
+      - "2024/*"
+  - label: "The Psychology Of Computer Programming"
+    files:
+      - "2024/ThePsychologyOfComputerProgramming/*"

--- a/.github/workflows/on_pr_opened.yaml
+++ b/.github/workflows/on_pr_opened.yaml
@@ -1,0 +1,39 @@
+name: "On Pull Request Opened"
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.0.0
+
+  add-reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ohnogumi/auto-reviewers@v0.0.5
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: srvaroa/labeler@master
+        with:
+          config_path: .github/configs/labeler.yml
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  comment-for-filling-others-like-projects-milestone-development-etc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JoseThen/comment-pr@v1.2.0
+        with:
+          comment: "우측에 있는 `Projects`, `Milestone`, `Development`를 확인 후 할당 해주세요~! :bow:"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# 제안
* @jongfeel 님, PR 생성 시, 수동으로 해야하는 것들을 자동화할 수 있는 것들은 자동화해보면 좋을것 같습니다 🙇🏻 
    * 책 모임 활동과는 직접적인 관계는 없는 PR이라서(프로세스를 개선을 위한 간접적인 활동?..), 당장 적용할 필요가 없다면 이 PR은 무시해주셔도 좋습니다~ 😄 
* 일단 제 생각대로 이렇게 하면 어떨까? 라고 생각해서 해봤는데요 의견 주시면 적극 반영하도록 하겠습니다 의견 부탁드립니다! 🙇🏻 


## 문제
* 우측 reviewers, asignees, labels, projets, milestone, development 등을 매번 PR 생성할 때마다 채워줘야 하는데, 사람의 손으로 일일이 수동으로 넣다보니 까먹고 안넣을 때도 있고 잘못 기입할 때도 있음

## 해결
* github actions를 사용해서, 자동화 처리 한다

## 조건
* github actions market에 기존에 만들어둔 actions가 있다면, 적극 활용 한다
* 없다면, github api를 활용해, 직접 actions를 만드는 것을 고려 해보고 만들기 전까지는 대체할 수 있는 방법을 고민하고 적용한다

## 검증
* reviewers 가 자동으로 지정 되어야 한다 -> ✅ 
* Assignees 가 자동으로 지정 되어야 한다 -> ✅ 
* Labels이 각 책과 연도에 맞게 할당 되어야 한다 -> ✅ 
* 책에 따라서, Projects 할당 되어야 한다 -> ❌ (코멘트로 대체)
* 책에 따라서, Milestone 할당 되어야 한다 -> ❌ (코멘트로 대체) 
* 특정 이슈에 따라서, Development 할당 되어야 한다 -> ❌ (코멘트로 대체) 

## 기대결과
* PR 생성 시에 수동으로 해야할 것들이 줄어듬으로써, 실수도 줄어든다
* 앞으로도 자동화 해야할게 있을 때, actions를 적극 활용할 수 있다
    * 마켓에서 다른 사람이 만들어둔 것을 사용할 수도 있고, 아님 직접 개발할 수도 있음

## 참고
* Projects, Milestone, Delveopment는 github actions market에서 적절한 actions를 찾지 못하였고, github API를 활용해서, 직접 개발하는 방향으로 고려 필요하다고 판단하였고, **대신에 PR이 생성되고 나서 코멘트를 추가로 달아서, PR 생성자가 확인 후 채워둘 수 있도록 함**

* 추후에 위에 ❌ 로 된 것들은 github API로 직접 actions를 만들어보려고 합니다

* 그외 추가로 시도 해본 것
    - 한글 맞춤법 체크를 해주면 좋을 것 같아서, 테스트 해봤는데 한두줄 정도 체크하는 것은 이상이 없는데 그 이상 넘어가면 계속 에러가 나고, 사용성이 좋지 않아서 도입은 포기했습니다

## 화면
* 적용했을 때, 대략 요렇게 됩니다
![스크린샷 2023-12-31 오후 9 49 33](https://github.com/ThinkAboutSoftware/AcademicConference/assets/18538418/729d6188-3d43-48fa-9c96-1975491bf99a)

![스크린샷 2023-12-31 오후 9 52 49](https://github.com/ThinkAboutSoftware/AcademicConference/assets/18538418/3f6788c4-6b91-47a0-93ac-95449872df26)
